### PR TITLE
[OPER-4637] Report Kakfa topic offsets to Signalfx.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,6 +15,9 @@ object KafkaUtilsBuild extends Build {
 
     mergeStrategy in assembly := {
       case "about.html" => MergeStrategy.discard
+      case "jetty-dir.css" => MergeStrategy.discard
+      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+
       case x =>
         val oldStrategy = (mergeStrategy in assembly).value
         oldStrategy(x)
@@ -24,7 +27,7 @@ object KafkaUtilsBuild extends Build {
       "com.google.guava" % "guava" % "18.0",
       "com.quantifind" % "kafkaoffsetmonitor_2.11" % "0.4.6-SNAPSHOT",
       "io.dropwizard.metrics" % "metrics-graphite" % "3.1.2",
-      "com.signalfx.public" % "signalfx-codahale" % "0.2.1" % "provided",
+      "com.signalfx.public" % "signalfx-codahale" % "0.2.1",
 
       "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test",
       "com.jayway.awaitility" % "awaitility" % "1.6.1" % "test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,6 +24,7 @@ object KafkaUtilsBuild extends Build {
       "com.google.guava" % "guava" % "18.0",
       "com.quantifind" % "kafkaoffsetmonitor_2.11" % "0.4.6-SNAPSHOT",
       "io.dropwizard.metrics" % "metrics-graphite" % "3.1.2",
+      "com.signalfx.public" % "signalfx-codahale" % "0.2.1" % "provided",
 
       "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test",
       "com.jayway.awaitility" % "awaitility" % "1.6.1" % "test"

--- a/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporter.scala
+++ b/src/main/scala/pl/allegro/tech/kafka/offset/monitor/graphite/OffsetGraphiteReporter.scala
@@ -8,6 +8,9 @@ import com.codahale.metrics.graphite.{GraphiteReporter, Graphite}
 import com.google.common.cache._
 import com.quantifind.kafka.OffsetGetter.OffsetInfo
 import com.codahale.metrics.Gauge
+import com.signalfx.codahale._
+import com.signalfx.codahale.reporter.SignalFxReporter
+
 
 class OffsetGraphiteReporter (pluginsArgs: String) extends com.quantifind.kafka.offsetapp.OffsetInfoReporter {
 
@@ -24,6 +27,15 @@ class OffsetGraphiteReporter (pluginsArgs: String) extends com.quantifind.kafka.
     .build(graphite)
 
   reporter.start(GraphiteReporterArguments.graphiteReportPeriod, TimeUnit.SECONDS)
+
+  // Send offset metrics to signalfx
+  // Hardcoding key values for the time being.
+  val signalFxReporter = new SignalFxReporter.Builder(metrics, "hDlqZogIdGTFCbQHpmNiNQ").build()
+
+  signalFxReporter.start(30, TimeUnit.SECONDS)
+
+  val metricMetadata = signalFxReporter.getMetricMetadata()
+  val sfxMetrics = new SfxMetrics(metrics, metricMetadata)
 
   val removalListener : RemovalListener[String, GaugesValues] = new RemovalListener[String, GaugesValues] {
     override def onRemoval(removalNotification: RemovalNotification[String, GaugesValues]) = {


### PR DESCRIPTION
cc @tapdaq/eng-group-ops @alanbrent @jingniwei 

In an effort to further unify Tapdaq and Tapjoy's moniroting resources, we would like to report kafka topic offsets to both graphite and SignaflFX.

The following change is meant to be as minimally invasive to the already configured and running job  as possible (vs adding another jar that would change invocation semantics)

References for library used:

https://github.com/signalfx/signalfx-java

This is the first time I've written any scala whatsoever so any and all feedback is welcomed. 

Using a locally running sbt/scalal Docker container I have validated the code jar will compile in it's current state:

<details>
<summary>Local Development Build</summary>

```
root@e3b28ebcc2e3:/project/kafka-offset-monitor-graphite# sbt assembly
[info] Loading project definition from /project/kafka-offset-monitor-graphite/project
[info] Set current project to kafka-offset-monitor-graphite (in build file:/project/kafka-offset-monitor-graphite/)
[info] Compiling 1 Scala source to /project/kafka-offset-monitor-graphite/target/scala-2.11/classes...
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.CheckReturnValue not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] Class javax.annotation.Nullable not found - continuing with a stub.
[warn] 9 warnings found
[info] OffsetGraphiteReporterTest:
[info] - should report metrics to graphite
[info]   + Given offset 
[info]   + When reporting 
[info]   + Then expect metrics to be delivered 
[info] - should escape names of topic and groups
[info]   + Given offset for topic and group with dots 
[info]   + When reporting 
[info]   + Then expect metrics to be delivered 
[info] - should not fail to recreate metrics after cache has expired
[info]   + Given offset 
[info]   + When waiting for cache to expire and reporting again 
[info]   + Then expect metrics to be delivered 
[info] Run completed in 5 seconds, 800 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Including from cache: paranamer-2.6.jar
[info] Including from cache: zkclient-0.7.jar
[info] Including from cache: jline-0.9.94.jar
[info] Including from cache: jetty-io-8.1.13.v20130916.jar
[info] Including from cache: config-1.2.1.jar
[info] Including from cache: junit-3.8.1.jar
[info] Including from cache: metrics-core-2.2.0.jar
[info] Including from cache: jetty-security-8.1.13.v20130916.jar
[info] Including from cache: commons-codec-1.4.jar
[info] Including from cache: gson-2.8.2.jar
[info] Including from cache: jetty-server-8.1.13.v20130916.jar
[info] Including from cache: metrics-core-3.1.2.jar
[info] Including from cache: util-core_2.11-7.1.0.jar
[info] Including from cache: guava-20.0.jar
[info] Including from cache: log4j-1.2.17.jar
[info] Including from cache: metrics-graphite-3.1.2.jar
[info] Including from cache: util-function_2.11-7.1.0.jar
[info] Including from cache: jetty-servlet-8.1.13.v20130916.jar
[info] Including from cache: sumac_2.11-0.3.0.jar
[info] Including from cache: unfiltered-filter_2.11-0.8.4.jar
[info] Including from cache: jetty-util-8.1.13.v20130916.jar
[info] Including from cache: javassist-3.21.0-GA.jar
[info] Including from cache: netty-3.7.0.Final.jar
[info] Including from cache: unfiltered-jetty_2.11-0.8.4.jar
[info] Including from cache: json4s-ast_2.11-3.2.9.jar
[info] Including from cache: jetty-webapp-8.1.13.v20130916.jar
[info] Including from cache: javax.annotation-api-1.2.jar
[info] Including from cache: unfiltered-json4s_2.11-0.8.4.jar
[info] Including from cache: jetty-xml-8.1.13.v20130916.jar
[info] Including from cache: javax.ws.rs-api-2.0-m16.jar
[info] Including from cache: slick_2.11-2.1.0.jar
[info] Including from cache: json4s-core_2.11-3.2.9.jar
[info] Including from cache: unfiltered-util_2.11-0.8.4.jar
[info] Including from cache: aopalliance-repackaged-2.5.0-b32.jar
[info] Including from cache: json4s-native_2.11-3.2.9.jar
[info] Including from cache: lz4-1.2.0.jar
[info] Including from cache: reflections-0.9.11.jar
[info] Including from cache: javax.inject-2.5.0-b32.jar
[info] Including from cache: jopt-simple-3.2.jar
[info] Including from cache: unfiltered_2.11-0.8.4.jar
[info] Including from cache: slf4j-log4j12-1.7.6.jar
[info] Including from cache: scala-parser-combinators_2.11-1.0.4.jar
[info] Including from cache: hk2-api-2.5.0-b32.jar
[info] Including from cache: kafka-clients-0.9.0.1.jar
[info] Including from cache: snappy-java-1.1.1.7.jar
[info] Including from cache: hk2-locator-2.5.0-b32.jar
[info] Including from cache: scala-xml_2.11-1.0.4.jar
[info] Including from cache: hk2-utils-2.5.0-b32.jar
[info] Including from cache: zookeeper-3.4.6.jar
[info] Including from cache: osgi-resource-locator-1.0.1.jar
[info] Including from cache: javax.servlet-3.0.0.v201112011016.jar
[info] Including from cache: scala-library-2.11.11.jar
[info] Including from cache: kafka_2.11-0.9.0.1.jar
[info] Including from cache: jersey-guava-2.25.1.jar
[info] Including from cache: jetty-continuation-8.1.13.v20130916.jar
[info] Including from cache: jersey-client-2.25.1.jar
[info] Including from cache: jetty-http-8.1.13.v20130916.jar
[info] Including from cache: jersey-common-2.25.1.jar
[info] Including from cache: sqlite-jdbc-3.18.0.jar
[info] Including from cache: scalap-2.11.0.jar
[info] Including from cache: scala-reflect-2.11.11.jar
[info] Including from cache: kafkaoffsetmonitor_2.11-0.4.6-SNAPSHOT.jar
[info] Including from cache: slf4j-api-1.7.7.jar
[info] Including from cache: scala-compiler-2.11.0.jar
[warn] Merging 'META-INF/MANIFEST.MF' with strategy 'discard'
[warn] Merging 'META-INF/ECLIPSEF.SF' with strategy 'discard'
[warn] Merging 'about.html' with strategy 'discard'
[warn] Merging 'rootdoc.txt' with strategy 'concat'
[warn] Strategy 'concat' was applied to a file
[warn] Strategy 'discard' was applied to 3 files
[info] Checking every *.class/*.jar file's SHA-1.
[info] SHA-1: 90b1ab03d2dc593a30b7d04ca827c6e0a0dbb92d
[info] Packaging /project/kafka-offset-monitor-graphite/target/scala-2.11/kafka-offset-monitor-graphite-assembly-0.1.0-SNAPSHOT.jar ...
[info] Done packaging.
[success] Total time: 765 s, completed Nov 25, 2019 9:24:17 PM
root
```

</details>